### PR TITLE
Evento dao testing

### DIFF
--- a/src/logic/AmbienteAgricolo/AmbienteAgricoloService.py
+++ b/src/logic/AmbienteAgricolo/AmbienteAgricoloService.py
@@ -127,7 +127,7 @@ class AmbienteAgricoloService():
     def aggiungiIrrigatore(id_terreno: str, nome_irrigatore: str, posizione_irrigatore: str) -> str:
         impianto = ImpiantoDiIrrigazione("", nome_irrigatore, "irrigatore", "", posizione_irrigatore, False)
         id = ImpiantoDiIrrigazioneDAO.creaImpianto(impianto, id_terreno)
-        evento = Evento("", "Creazione Irrigatore", "L'irrigatore :" + nome_irrigatore + " è stato creato",datetime.now(), "INFO",False ,False, id_terreno)
+        evento = Evento("", "Creazione Irrigatore", "L'irrigatore :" + nome_irrigatore + " è stato creato",datetime.now().isoformat(' ', 'seconds'), "INFO",False ,False, id_terreno)
         GestioneEventiService.creaEvento(evento)
         return id
     
@@ -186,7 +186,7 @@ class AmbienteAgricoloService():
             somma += data["hourly"]["precipitation"][i]
         
         if somma > 10:
-            u = Evento("", "Pioggia", "Ci saranno ingenti quantità di pioggia nelle prossime 24 ore", datetime.now(), "Pioggia", False, False, "")
+            u = Evento("", "Pioggia", "Ci saranno ingenti quantità di pioggia nelle prossime 24 ore", datetime.now().isoformat(' ', 'seconds'), "Pioggia", False, False, "")
             GestioneEventiService.creaEvento(u)
         
         return data

--- a/src/logic/GestioneSchedule/GestioneScheduleController.py
+++ b/src/logic/GestioneSchedule/GestioneScheduleController.py
@@ -26,7 +26,7 @@ class GestioneScheduleController:
         
         GestioneScheduleService.modificaLivelloSchedule(id_terreno, data, modalita)
         evento = Evento("", "Scheduling", "Livello di irrigazione modificato per la data " + data +" con la modalità " + modalita
-                        , datetime.now(), "Scheduling", False, False, id_terreno)
+                        , datetime.now().isoformat(' ', 'seconds'), "Scheduling", False, False, id_terreno)
         print(evento)
         GestioneEventiService.creaEvento(evento)        
         return jsonify({"success": True})

--- a/src/logic/GestioneSchedule/GestioneScheduleService.py
+++ b/src/logic/GestioneSchedule/GestioneScheduleService.py
@@ -31,6 +31,6 @@ class GestioneScheduleService:
                 print("errore nell'aggiornamento dello schedule")
                 break
             
-        evento = Evento("", "Scheduling", "Scheduling consigliato applicato", datetime.datetime.now(), "Scheduling", False, False, id_terreno)
+        evento = Evento("", "Scheduling", "Scheduling consigliato applicato", datetime.datetime.now().isoformat(' ', 'seconds'), "Scheduling", False, False, id_terreno)
         GestioneEventiService.creaEvento(evento)
         return result

--- a/src/logic/Storage/EventoDAO.py
+++ b/src/logic/Storage/EventoDAO.py
@@ -19,7 +19,8 @@ class EventoDAO():
         tipo = str(trovato.get("tipo"))
         azione_umana = bool(trovato.get("azione_umana"))
         visto = bool(trovato.get("visto"))
-        eventoTrovato = Evento(id, titolo, descrizione, orario, tipo, azione_umana, visto)
+        terreno = str(trovato.get("terreno"))
+        eventoTrovato = Evento(id, titolo, descrizione, orario, tipo, azione_umana, visto, terreno)
         return eventoTrovato
     
     def creaEvento(evento : Evento) -> str:
@@ -54,9 +55,14 @@ class EventoDAO():
     
     def cancellaTuttiEventiByTerreno(idTerreno:str):
         eventiTrovati = eventi.delete_many({"terreno" : idTerreno})
+        return eventiTrovati.deleted_count
         
     def cancellaEvento(idEvento:str):
         eventiTrovati = eventi.delete_one({"_id" : ObjectId(idEvento)})
+        if(eventiTrovati.deleted_count == 1):
+            return True
+        else:
+            return False
 
 
 

--- a/src/logic/model/Evento.py
+++ b/src/logic/model/Evento.py
@@ -13,5 +13,10 @@ class Evento():
         self.visto = visto
         self.terreno = terreno
     
+    def __eq__(self, __o: object) -> bool:
+        if(self.titolo == __o.titolo and self.descrizione == __o.descrizione and self.orario == __o.orario and self.tipo == __o.tipo and self.azione_umana == __o.azione_umana and self.visto == __o.visto and self.terreno == __o.terreno):
+            return True
+        else:
+            return False
 
 

--- a/src/unittest/python/DAO_tests.py
+++ b/src/unittest/python/DAO_tests.py
@@ -2,6 +2,7 @@ import os
 import sys
 from unittest import mock
 import unittest
+import datetime
 
 sys.path.append(os.path.abspath(os.path.join('.' )))
 from src import app
@@ -216,6 +217,47 @@ class LicenzaDAOTests(unittest.TestCase):
         print("eliminaLicenza")
         result = LicenzaDAO.eliminaLicenza(self.licenzaID)
         self.assertEqual(result, True)     
+ 
+class EventoDAOTests(unittest.TestCase):
+    
+    def setUp(self):
+        self.evento = Evento("", "Scheduling", "Scheduling consigliato applicato", datetime.datetime.now().isoformat(' ', 'seconds'), "Scheduling", False, True, "63d1a61ecf0e0efd3dee3asw")
+        print(self.evento.orario)
+        self.eventoID = EventoDAO.creaEvento(self.evento)
+        self.eventoExpected = EventoDAO.findEvento(self.eventoID)
+        print(self.eventoExpected.orario)
+        
+    def tearDown(self):
+        EventoDAO.cancellaEvento(self.eventoID)
+            
+    def test_findEvento_pass(self):
+        print("findEvento")
+        eventoResult = EventoDAO.findEvento(self.eventoID)
+        self.assertEqual(eventoResult, self.eventoExpected)
+
+    def test_creaEvento_pass(self):
+        print("creaEvento")
+        self.assertEqual(self.evento, self.eventoExpected)
+    
+    def test_findEventiByTerreno_pass(self):
+        print("findEventiByTerreno")
+        evento2 = Evento("", "Scheduling", "Scheduling consigliato applicato", datetime.datetime.now().isoformat(' ', 'seconds'), "Scheduling", False, False, "63d1a61ecf0e0efd3dee3asw")
+        evento2ID = EventoDAO.creaEvento(evento2)
+        results = list(EventoDAO.findEventiByTerreno(evento2.terreno))
+        EventoDAO.cancellaEvento(evento2ID)
+        self.assertGreaterEqual(len(results), 2)
+    
+    def test_cancellaTuttiEventiByTerreno_pass(self):
+        print("cancellaEvento")
+        evento2 = Evento("", "Scheduling", "Scheduling consigliato applicato", datetime.datetime.now().isoformat(' ', 'seconds'), "Scheduling", False, False, "63d1a61ecf0e0efd3dee3asw")
+        evento2ID = EventoDAO.creaEvento(evento2)
+        result = EventoDAO.cancellaTuttiEventiByTerreno(evento2.terreno)
+        self.assertEqual(result, 2)     
+    
+    def test_cancellaEvento_pass(self):
+        print("cancellaEvento")
+        result = EventoDAO.cancellaEvento(self.eventoID)
+        self.assertEqual(result, True)     
         
 if __name__ == '__main__':
     print("Partenza test di TerrenoDAO")
@@ -232,5 +274,9 @@ if __name__ == '__main__':
     test.run()
     print("Partenza test di LicenzaPagamentoDAO")
     test = LicenzaDAOTests()
+    test.setUp()
+    test.run()
+    print("Partenza test di EventoDAO")
+    test = EventoDAOTests()
     test.setUp()
     test.run()


### PR DESCRIPTION
Added tests for EventoDAO, equals function, also fixes a MongoDB bug where the date would be saved incorrectly, with different microseconds, creating problems for testing. Solved by adding to datetime.now() .isoformat(' ', "seconds"). 

Changes the MongoDB field to String instead of DateTime.

Tested from web as well as previous tests, no problems found.